### PR TITLE
Replace set-output command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,6 @@ fi
 
 git config --global credential.helper store
 
-SHA=`git ls-remote "${GIT_REPO}" "${GIT_BRANCH}" | awk '{print $1}'`
+SHA=$(git ls-remote "${GIT_REPO}" "${GIT_BRANCH}" | awk '{print $1}')
 
-echo "::set-output name=sha::$SHA"
+echo "sha=${SHA}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
Replace the deprecated 'set-output' command. See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/